### PR TITLE
fixing memory leaks from itoa from the expansion of exit_status

### DIFF
--- a/srcs/expand/expand.c
+++ b/srcs/expand/expand.c
@@ -7,6 +7,7 @@ char	*expand_str(size_t expanded_len, char *str, t_env *env_list, int exit_statu
 	char *var_name;
 	char *value;
 	char *expanded;
+	char *temp_value;
 
 	i = 0;
 	k = 0;
@@ -17,10 +18,14 @@ char	*expand_str(size_t expanded_len, char *str, t_env *env_list, int exit_statu
 	{
 		if (str[i] == '$' && str[i + 1] == '?')
 		{
-			value = ft_itoa(exit_status);
-			while (*value)
-				expanded[k++] = *value++;
-			i += 2;
+			 value = ft_itoa(exit_status);
+            if (!value)
+                return (free(expanded), NULL);
+            temp_value = value;
+            while (*value)
+                expanded[k++] = *value++;
+            free(temp_value);
+            i += 2;
 		}
 		else
 		if (str[i] == '$' && (ft_isalnum(str[i + 1]) || str[i + 1] == '_'))

--- a/srcs/expand/expand_utils.c
+++ b/srcs/expand/expand_utils.c
@@ -6,6 +6,7 @@ size_t	calc_expanded_len(char *str, t_env *env_list, int exit_status)
 	int i;
 	char *var_name;
 	char *value;
+	char *itoa_str;
 
 	expanded_len = 0;
 	i = 0;
@@ -13,8 +14,12 @@ size_t	calc_expanded_len(char *str, t_env *env_list, int exit_status)
 	{
 		if(str[i] == '$' && str[i + 1] == '?')
 		{
-			expanded_len += ft_strlen(ft_itoa(exit_status));
-			i += 2;
+			 itoa_str = ft_itoa(exit_status);
+            if (!itoa_str)
+                return 0;
+            expanded_len += ft_strlen(itoa_str);
+            free(itoa_str);
+            i += 2;
 		}
 		else
 		if (str[i] == '$' && (ft_isalnum(str[i + 1]) || str[i + 1] == '_'))


### PR DESCRIPTION
Sorry again for this annoying memory leaks! this time I wasn't freeing after using itoa 🤦‍♀️ 
Though, I think there is something wrong perhaps in another part of the code, because when running something like ls /non the exit_status is 2, and as far as I know should be 1. What do you think?