### PR TITLE
adding exit builtin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ SRCS = srcs/main.c srcs/exits.c srcs/get_input/parsing.c srcs/get_input/split_li
        srcs/execution/redir_utils.c srcs/execution/redirection.c srcs/execution/heredoc.c \
        srcs/builtins/export.c srcs/builtins/unset.c srcs/global/env_utils.c srcs/expand/expand_utils.c \
        srcs/global/global_init.c srcs/execution/pipes.c srcs/get_input/syntax.c \
-       srcs/global/init_utils.c srcs/get_input/split_utils.c srcs/execution/heredoc_utils.c
+       srcs/global/init_utils.c srcs/get_input/split_utils.c srcs/execution/heredoc_utils.c srcs/builtins/exit_cmd.c
 OBJS = $(SRCS:.c=.o)
 RM = rm -rf
 CC = cc

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   minishell.h                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: hzimmerm <hzimmerm@student.42berlin.de>    +#+  +:+       +#+        */
+/*   By: stephaniemanrique <stephaniemanrique@st    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: Invalid date        by                   #+#    #+#             */
-/*   Updated: 2024/08/22 19:54:14 by hzimmerm         ###   ########.fr       */
+/*   Updated: 2024/08/26 18:23:39 by stephaniema      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -134,7 +134,7 @@ int	divi_redirect(t_input **command, t_elements *elmts, int *i, int r_type);
 void	transfer_string(t_input **command, char *elmt, int offset, int type);
 
 /* free and exit functions */
-int	exit_shell(char *message, int exit_status);
+int	exit_shell(int exit_status);
 void	free_array(char **str);
 void	free_command(t_input **command);
 int	error_return(char *message);
@@ -144,9 +144,10 @@ int	what_builtin(char **command_words, t_global *global);
 void	echo(char **str, t_global *global);
 void	pwd(t_global *global);
 void	cd(char *path, t_global *global);
-void	cmd_env(char **command_words, t_global *global);
+void	env_cmd(char **command_words, t_global *global);
 void	export(char **words, t_global *global);
 void	unset(char **args, t_global *global);
+void	exit_cmd(char **command_words, t_global *global);
 void	error_identifier(char *str, char *command);
 
 /* global */

--- a/srcs/builtins/env.c
+++ b/srcs/builtins/env.c
@@ -1,7 +1,7 @@
 
 #include "../../includes/minishell.h"
 
-void	cmd_env(char **command_words, t_global *global)
+void	env_cmd(char **command_words, t_global *global)
 {
 	t_env *temp;
 

--- a/srcs/builtins/exit_cmd.c
+++ b/srcs/builtins/exit_cmd.c
@@ -1,0 +1,57 @@
+#include "../../includes/minishell.h"
+
+int	is_valid_number(char *arg)
+{
+	size_t	i = 0;
+
+	if (arg[0] == '+' || arg[0] == '-')
+	i++;
+	while (arg[i])
+	{
+		if (!ft_isdigit(arg[i]))
+			return (0);
+		i++;
+	}
+	return (1);
+}
+
+void	handle_exit_status(char **command_words, t_global *global)
+{
+	if (command_words[2])
+	{
+		ft_putstr_fd("minishell: exit: too many arguments\n", 2);
+		global->exit_status = 1;
+		return;
+	}
+	if (!is_valid_number(command_words[1]))
+	{
+		ft_putstr_fd("minishell: exit: ", 2);
+		ft_putstr_fd(command_words[1], 2);
+		ft_putstr_fd(": numeric argument required\n", 2);
+		global->exit_status = 255;
+		return;
+	}
+	global->exit_status = ft_atoi(command_words[1]);
+}
+
+void	cleanup_and_exit(t_global *global)
+{
+	rl_clear_history();
+	free_env_list(&global->env_list);
+	free_array(global->env);
+	free(global);
+	exit(global->exit_status);
+}
+
+void	exit_cmd(char **command_words, t_global *global)
+{
+	if (command_words[1])
+	{
+		handle_exit_status(command_words, global);
+		if (command_words[2] || global->exit_status == 255)
+			return;
+	}
+	else
+		global->exit_status = 0;
+	cleanup_and_exit(global);
+}

--- a/srcs/builtins/what_builtin.c
+++ b/srcs/builtins/what_builtin.c
@@ -15,8 +15,8 @@ int	what_builtin(char **command_words, t_global *global)
 	if(!ft_strncmp(command_words[0], "unset", 5))
 		unset(command_words, global);
 	if(!ft_strncmp(command_words[0], "env", 3))
-	 	cmd_env(command_words, global);
-	// if(!ft_strncmp(command_words[0], "exit", 4))
-	// 	exit();
+	 	env_cmd(command_words, global);
+	if(!ft_strncmp(command_words[0], "exit", 4))
+		exit_cmd(command_words, global);
 	return (global->exit_status);
 }

--- a/srcs/exits.c
+++ b/srcs/exits.c
@@ -3,21 +3,21 @@
 /*                                                        :::      ::::::::   */
 /*   exits.c                                            :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: hzimmerm <hzimmerm@student.42berlin.de>    +#+  +:+       +#+        */
+/*   By: stephaniemanrique <stephaniemanrique@st    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/07/13 15:13:31 by Henriette         #+#    #+#             */
-/*   Updated: 2024/08/22 17:53:29 by hzimmerm         ###   ########.fr       */
+/*   Updated: 2024/08/26 18:23:09 by stephaniema      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../includes/minishell.h"
 
-int	exit_shell(char *message, int exit_status)
+int	exit_shell(int exit_status)
 {
-	if (exit_status == EXIT_SUCCESS && message != NULL)
-		ft_putstr_fd(message, 2);
-	if (exit_status == EXIT_FAILURE && message != NULL)
-		perror(message);
+	//if (exit_status == EXIT_SUCCESS && message != NULL)
+		//ft_putstr_fd(message, 2);
+	//if (exit_status == EXIT_FAILURE && message != NULL)
+		//perror(message);
 	rl_clear_history();
 	exit(exit_status);
 }

--- a/srcs/global/global_init.c
+++ b/srcs/global/global_init.c
@@ -75,7 +75,7 @@ void	global_init(t_global **global, char **env)
 	env_array = NULL;
 	*global = malloc(sizeof(t_global));
 	if (!*global)
-		exit_shell("Error: malloc failed\n", EXIT_FAILURE);
+		exit_shell(EXIT_FAILURE);
 	(*global)->exit_status = 0;
 	(*global)->pwd = getenv("PWD");
 	if(env_init(env, &env_list))

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   main.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: hzimmerm <hzimmerm@student.42berlin.de>    +#+  +:+       +#+        */
+/*   By: stephaniemanrique <stephaniemanrique@st    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/07/13 14:51:25 by Henriette         #+#    #+#             */
-/*   Updated: 2024/08/22 17:54:09 by hzimmerm         ###   ########.fr       */
+/*   Updated: 2024/08/26 18:23:23 by stephaniema      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -30,7 +30,7 @@ int	main(int argc, char **argv, char **env)
 		{
 			remove_heredoc(env, global->pwd, global->exit_status);
 			close(global->history_fd);
-			return (exit_shell("exit\n", EXIT_SUCCESS));
+			return (exit_shell(EXIT_SUCCESS));
 		}
 		if (*cmd_line)
 		{


### PR DESCRIPTION
Hey Henri!! now we have the exit builtin and are approving 141/146 tests 🥳 !!

Working on this part I found that the error we had before in all the tests has something to do with the exit_shell function,  when I commented the part of this function that prints errors now passes all the tests.

Now I'm moving on with signals! yayyy!